### PR TITLE
Make StarlightBlog work with StarlightImageZoom

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -2,8 +2,8 @@ import starlight from "@astrojs/starlight";
 import starlightUtils from "@lorenzo_lewis/starlight-utils";
 import { defineConfig } from "astro/config";
 import starlightBlog from "starlight-blog";
+import starlightImageZoom from "starlight-image-zoom";
 // import starlightLinksValidator from 'starlight-links-validator';
-// import starlightImageZoom from 'starlight-image-zoom';
 // import starWarp from '@inox-tools/star-warp';
 
 import react from "@astrojs/react";
@@ -25,6 +25,7 @@ export default defineConfig({
     starlight({
       favicon: "/favicon.png",
       plugins: [
+        starlightImageZoom(),
         starlightBlog(),
         starlightUtils({
           navLinks: {
@@ -58,6 +59,7 @@ export default defineConfig({
       },
       components: {
         Pagination: "./src/components/CustomPagination.astro",
+        MarkdownContent: "./src/components/MarkdownContent.astro",
       },
       sidebar: [
         {

--- a/src/components/MarkdownContent.astro
+++ b/src/components/MarkdownContent.astro
@@ -1,0 +1,8 @@
+---
+import type { Props } from '@astrojs/starlight/props'
+import Default from "starlight-blog/overrides/MarkdownContent.astro"
+import ImageZoom from 'starlight-image-zoom/components/ImageZoom.astro'
+---
+
+<ImageZoom />
+<Default {...Astro.props}><slot /></Default>


### PR DESCRIPTION
Hello!

I see that you wanted to use the Starlight Image Zoom but commented it in the `astro.config.mjs` file.
There is a common problem when using Starlight Image Zoom together with Starlight Blog, so maybe that's the reason you don't currently use it.

Fortunately for you, in this PR I have updated your code, so the Image Zoom should work together with the Starlight Blog.

Have a nice day, bye!